### PR TITLE
updated smbshare to be able to get connected share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target/
+
+.idea
+*.iws
+*.iml
+*.ipr

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
@@ -105,6 +105,11 @@ public class SmbShare implements AutoCloseable {
         return share;
     }
 
+    public DiskShare connectAndGetShare(String path){
+        connect(path);
+        return getShare();
+    }
+
     /**
      * @return The DFS resolved path, if DFS is used. Otherwise the supplied path is returned
      */


### PR DESCRIPTION
Updated smb share to be able to get the connected share. As I've seen getshare method returns the connected share but visibility of connect method does not allow us to connect without doing any other operation. So connectAndGet will help to do that.